### PR TITLE
Issue #9: Fix deleting files with spaces in the name

### DIFF
--- a/lua/sidebar-nvim/builtin/files.lua
+++ b/lua/sidebar-nvim/builtin/files.lua
@@ -276,7 +276,7 @@ local function delete_file(src, trash, confirm_deletion)
         end
     end
 
-    os.execute(string.format("mv %s %s", src, trash))
+    os.execute(string.format("mv \"%s\" \"%s\"", src, trash))
 end
 
 local function create_directory(dest)


### PR DESCRIPTION
Files with spaces in their name could not be deleted. Fixed this by surrounding paths in quotes.

closes #9 